### PR TITLE
Decompose overflowing composites

### DIFF
--- a/babelfont-rs/src/layer.rs
+++ b/babelfont-rs/src/layer.rs
@@ -46,16 +46,6 @@ impl Layer {
         })
     }
 
-    pub fn components_mut(&mut self) -> impl DoubleEndedIterator<Item = &mut Component> {
-        self.shapes.iter_mut().filter_map(|x| {
-            if let Shape::ComponentShape(c) = x {
-                Some(c)
-            } else {
-                None
-            }
-        })
-    }
-
     pub fn paths(&self) -> impl DoubleEndedIterator<Item = &Path> {
         self.shapes.iter().filter_map(|x| {
             if let Shape::PathShape(p) = x {

--- a/babelfont-rs/src/layer.rs
+++ b/babelfont-rs/src/layer.rs
@@ -46,6 +46,16 @@ impl Layer {
         })
     }
 
+    pub fn components_mut(&mut self) -> impl DoubleEndedIterator<Item = &mut Component> {
+        self.shapes.iter_mut().filter_map(|x| {
+            if let Shape::ComponentShape(c) = x {
+                Some(c)
+            } else {
+                None
+            }
+        })
+    }
+
     pub fn paths(&self) -> impl DoubleEndedIterator<Item = &Path> {
         self.shapes.iter().filter_map(|x| {
             if let Shape::PathShape(p) = x {

--- a/fonticulus/src/buildbasic.rs
+++ b/fonticulus/src/buildbasic.rs
@@ -268,17 +268,16 @@ fn decompose_overflowing_components(input: &mut babelfont::Font) {
     // Round 1: Remember all glyphs with components that go beyond the F2DOT14 range, to
     // decompose in round 2.
     let mut glyphs_to_be_decomposed = Vec::new();
-    'next_glyph: for (index, glyph) in input.glyphs.iter_mut().enumerate() {
-        for layer in &mut glyph.layers {
-            for component in layer.components_mut() {
-                let mut transform = component.transform.as_coeffs();
-                for coeff in transform[..4].iter_mut() {
+    'next_glyph: for (index, glyph) in input.glyphs.iter().enumerate() {
+        for layer in &glyph.layers {
+            for component in layer.components() {
+                let transform = component.transform.as_coeffs();
+                for coeff in transform[..4].iter() {
                     if *coeff < -2.0 || *coeff > 2.0 {
                         glyphs_to_be_decomposed.push(index);
                         continue 'next_glyph;
                     }
                 }
-                component.transform = kurbo::Affine::new(transform);
             }
         }
     }

--- a/fonttools-cli/src/bin/fontcrunch.rs
+++ b/fonttools-cli/src/bin/fontcrunch.rs
@@ -679,6 +679,7 @@ fn main() {
         pb.set_style(
             ProgressStyle::default_bar()
                 .template("[{bar:52}] {pos:>7}/{len:7} {eta_precise}")
+                .expect("invalid template")
                 .progress_chars("█░ "),
         );
 


### PR DESCRIPTION
This makes Cantarell compile.

I need to test F2DOT14 conversion in general somehow and add a test case.

I suppose the mixed glyph decomposition function could be merged somehow. I want to implement the skip glyph behavior later, maybe I can come up with a more elegant solution.

Closes #13 